### PR TITLE
Make windows transparent

### DIFF
--- a/Models/Effects/ec135reflectglas-uber.eff
+++ b/Models/Effects/ec135reflectglas-uber.eff
@@ -2,7 +2,7 @@
 
 <PropertyList>
 	<name>ec135reflectglas-uber</name>
-	<inherits-from>Effects/model-combined-deferred</inherits-from>
+	<inherits-from>Effects/model-combined-transparent</inherits-from>
 	<parameters>
 		<rain-enabled type="int">1</rain-enabled>
 		<normalmap-enabled type="int">0</normalmap-enabled>


### PR DESCRIPTION
To have transparent windows, the effect needs to inherit from `Effects/model-combined-transparent`.
