### PR TITLE
Show transponder code in GTX330 display

### DIFF
--- a/Models/instrumentation/GTX330/GTX330.nas
+++ b/Models/instrumentation/GTX330/GTX330.nas
@@ -95,6 +95,25 @@ var updateDisplayedCode = func {
   canvas_elements["squawk"].setText(sprintf("%04d", GTX330_code.getValue()));
 }
 
+
+### Workaround, until https://sourceforge.net/p/flightgear/fgdata/merge-requests/60/ is merged.
+### React directly to changes in the "Radio Frequencies" dialog.
+var onTransponderDigitsChanged = func {
+  var goodcode = 1;
+  var code = 0;
+  for (var i = 3; i >= 0 ; i -= 1) {
+    goodcode = goodcode and (num(getprop("/instrumentation/transponder/inputs/digit[" ~ i ~ "]")) != nil) ;
+    code = code * 10 + (num(getprop("/instrumentation/transponder/inputs/digit[" ~ i ~ "]")) or 0);
+  }
+  if (goodcode) {
+    canvas_elements["squawk"].setText(sprintf("%04d", code));
+  }
+}
+for (var i = 0; i<4; i += 1) {
+  setlistener(props.globals.getNode("/instrumentation/transponder/inputs/digit[" ~ i ~ "]", 1), onTransponderDigitsChanged);
+}
+### End of workaround
+
 updateDisplay();
 updateDisplayedCode();
 setlistener(GTX330_mode, updateDisplay, 0, 0);

--- a/Models/instrumentation/GTX330/GTX330.nas
+++ b/Models/instrumentation/GTX330/GTX330.nas
@@ -91,10 +91,16 @@ var updateDisplay = func {
   GTX330Display_canvas.setColorBackground(display_colors[bg_color]);
 }
 
+var updateDisplayedCode = func {
+  canvas_elements["squawk"].setText(sprintf("%04d", GTX330_code.getValue()));
+}
+
 updateDisplay();
+updateDisplayedCode();
 setlistener(GTX330_mode, updateDisplay, 0, 0);
 setlistener(instrumentLights, updateDisplay, 0, 0);
 setlistener(batterySwitch, updateDisplay, 0, 0);
+setlistener(GTX330_code, updateDisplayedCode, 0, 1);
 
 var input = func(i) {
 		#setprop("/instrumentation/GTX330/input",getprop("/instrumentation/GTX330/input")~i);


### PR DESCRIPTION
The transponder code is read from `/instrumentation/transponder/id-code`~~, but only if it is valid (`/instrumentation/transponder/goodcode`)~~.

(see #4)
