### PR TITLE
Fix nasal warning

### DIFF
--- a/Nasal/limits.nas
+++ b/Nasal/limits.nas
@@ -126,7 +126,7 @@ var checkGandVNE = func {
   
   if ((TOW != nil) and (TOW > MTOW))
   {
-  msg = "Gross weight exceeds MTOW of 6251 lbs!";
+    msg = "Gross weight exceeds MTOW of " ~ math.ceil(MTOW) ~ " lbs!";
   }
   
   #Now Check TakeOffPower

--- a/Nasal/limits.nas
+++ b/Nasal/limits.nas
@@ -124,7 +124,7 @@ var checkGandVNE = func {
   var TOW =getprop("yasim/gross-weight-lbs");
   var MTOW = getprop("limits/MTOW");
   
-  if (TOW > MTOW)
+  if ((TOW != nil) and (TOW > MTOW))
   {
   msg = "Gross weight exceeds MTOW of 6251 lbs!";
   }


### PR DESCRIPTION
The nasal-console displayed the warning
```
Nasal runtime error: nil used in numeric context
  at /ec135/Nasal/limits.nas, line 127
  called from: /ec135/Nasal/limits.nas, line 163
```

Also, the check for MTOW correctly used the property value for the limit but the generated message had a hard-coded value in it.