### PR TITLE
Animated the holder for the headsets.

### DIFF
--- a/Models/interior.xml
+++ b/Models/interior.xml
@@ -34,10 +34,10 @@
 <animation>
 		<type>rotate</type>
 		<object-name>headset_holder</object-name>
-		<property>null</property>
-		<!--min-deg>0</min-deg-->
-		<!--max-deg>360</max-deg-->
-		<!--factor>1</factor-->
+	<property>sim/model/ec135/door-positions/headsetHolder/position-norm</property>
+	<min-deg>0</min-deg>
+	<max-deg>90</max-deg>
+	<factor>90</factor>
 		<center>
 			<x-m>0.747429</x-m>
 			<y-m>-0.001443</y-m>
@@ -49,6 +49,20 @@
 			<z>0.021732</z>
 		</axis>
 	</animation>
+
+<animation>
+	<type>pick</type>
+	<object-name>headset_holder</object-name>
+	<visible>true</visible>
+	<action>
+		<button>0</button>
+		<repeatable>false</repeatable>
+		<binding>
+			<command>nasal</command>
+			<script>ec135.headsetHolder.toggle();</script>
+		</binding>
+	</action>
+</animation>
 
 <!--Doors-->
 <animation>

--- a/Nasal/ec135.nas
+++ b/Nasal/ec135.nas
@@ -21,6 +21,9 @@ var min = func(a, b) a < b ? a : b;
 # liveries =========================================================
 aircraft.livery.init("Aircraft/ec135/Models/liveries");
 
+# holder for the headsets ================
+headsetHolder = aircraft.door.new( "/sim/model/ec135/door-positions/headsetHolder", 0.5, 0);
+
 #doors=========================
 leftFrontDoor = aircraft.door.new( "/sim/model/ec135/door-positions/leftFrontDoor", 4, 0 );
 rightFrontDoor = aircraft.door.new( "/sim/model/ec135/door-positions/rightFrontDoor", 4, 0 );


### PR DESCRIPTION
Clicking on it toggles between "ground" position (horizontal) and "in-flight" position (vertical) as seen in [this video](https://youtu.be/y7NEk0Pmrz4?t=24s).

While it works as intended, the following improvements should be considered:
* Remove the collision between the holder in its vertical position and the windscreen pillar.
* Move the property from `door-positions` to a new folder, e.g. `foldable-positions`, that can then hold the properties for other foldable items, e.g. the safety locks for the engine switches.
* Reassign the centerpiece of the holder from the fuselage (`interiorwall`) to the actual holder (`headset_holder`), so that the user can click on the centerpiece to start the animation.