### PR TITLE
enable buttons on the GTX330

### DIFF
--- a/Models/instrumentation/GTX330/GTX330.nas
+++ b/Models/instrumentation/GTX330/GTX330.nas
@@ -1,20 +1,13 @@
 #code snippets taken from the Boeing CDU and KT-76C by Gary Neely
 
-GTX330Input             = props.globals.getNode("/instrumentation/GTX330/input", 1);
-GTX330_code	 = props.globals.getNode("/instrumentation/transponder/id-code", 1);
-GTX330_goodcode	 = props.globals.getNode("/instrumentation/transponder/goodcode", 1);
-
-var GTX330_code		= props.globals.getNode("/instrumentation/transponder/id-code");
-var GTX330_Input             = props.globals.getNode("/instrumentation/GTX330/input");
-var GTX330_goodcode	= props.globals.getNode("/instrumentation/transponder/goodcode");
+var GTX330_digits = ""; # string to hold the user input
+var GTX330_code		= props.globals.getNode("/instrumentation/transponder/id-code", 1);
+var GTX330_goodcode	= props.globals.getNode("/instrumentation/transponder/goodcode", 1);
 var GTX330_mode = props.globals.getNode("/instrumentation/transponder/inputs/knob-mode", 1);
 
 var stopwatchDialog = props.globals.getNode("/sim/gui/dialogs/stopwatch-dialog/", 1);
 var instrumentLights = props.globals.getNode("/controls/lighting/instrument-lights");
 var batterySwitch = props.globals.getNode("/controls/electric/battery-switch");
-
-var GTX330_codes		= [];						# Array for 4 code digits
-var GTX330_last		= [];						# Holds copy of last known good code
 
 var mode_texts = {
   0 : "(off)",
@@ -121,19 +114,16 @@ setlistener(instrumentLights, updateDisplay, 0, 0);
 setlistener(batterySwitch, updateDisplay, 0, 0);
 setlistener(GTX330_code, updateDisplayedCode, 0, 1);
 
-var input = func(i) {
-		#setprop("/instrumentation/GTX330/input",getprop("/instrumentation/GTX330/input")~i);
-  append(GTX330_codes,i);
-GTX330_copycode();
+var input = func(i) { # The user pressed the button for number i
+    if (i <= 7) {
+        GTX330_digits = GTX330_digits ~ i;
+    }
 
- if (size(GTX330_codes) >= 4) { return 0; }
- if (size(GTX330_codes) == 4) {						# If we now have 4 digits, treat as a good
-   GTX330_last = GTX330_codes;						# code and save; flag that we have a good
-    GTX330_goodcode.setValue(1);	
-}  else {
-    GTX330_goodcode.setValue(0);
-  }
- GTX330_copycode();
+    if (size(GTX330_digits) == 4) { # If we now have 4 digits, set the transponder code
+        GTX330_goodcode.setBoolValue(1);
+        GTX330_code.setIntValue(GTX330_digits);
+        GTX330_digits = "";
+    }
 }
 
 var setMode = func(m) {
@@ -142,38 +132,12 @@ var setMode = func(m) {
 }
 
 var delete = func {
-  if (size(GTX330_codes)) {
-    pop(GTX330_codes);
-    GTX330_copycode();
+  if (size(GTX330_digits) > 0) {
+    # Remove the last digit
+    GTX330_digits = left(GTX330_digits, size(GTX330_digits) - 1);
   }
 }
 	
-
-
-var GTX330_copycode = func {
-#var GTX330_Input             = props.globals.getNode("/instrumentation/GTX330/input");
-  if (!size(GTX330_codes)) {
-    GTX330_code.setValue(0);
-    return 0;
-  }
-  var codestr = "";
-  for(var i=0; i < size(GTX330_codes); i+=1) {
-    codestr = codestr ~ GTX330_codes[i];
-  }
-  var code = 0;
-  code = math.mod(code + codestr, 10000);
-  GTX330_code.setValue(code);
-}
-
-
-	
-#var delete = func {
-#		var length = size(getprop("/instrumentation/GTX330/input")) - 1;
-#		setprop("/instrumentation/GTX330/input",substr(getprop("/instrumentation/GTX330/input"),0,length));
-#	}
-	
-var i = 0;
-
 var timestring = func(seconds) {
     var h = seconds / 3600;
     var m = int(math.mod(seconds / 60, 60));
@@ -194,23 +158,6 @@ var loop = func {
     settimer(loop, 0.33333);
 }
 
-var plusminus = func {	
-	var end = size(getprop("/instrumentation/GTX/input"));
-	var start = end - 1;
-	var lastchar = substr(getprop("/instrumentation/GTX/input"),start,end);
-	if (lastchar == "+"){
-		me.delete();
-		me.input('-');
-		}
-	if (lastchar == "-"){
-		me.delete();
-		me.input('+');
-		}
-	if ((lastchar != "-") and (lastchar != "+")){
-		me.input('+');
-		}
-	}
-	
 # Return true if the stopwatch is running, false otherwise.
 var stopwatchIsRunning = func {
     var dlg = globals["__dlg:stopwatch-dialog"];

--- a/Models/instrumentation/GTX330/GTX330.nas
+++ b/Models/instrumentation/GTX330/GTX330.nas
@@ -131,10 +131,20 @@ var setMode = func(m) {
   GTX330_mode.setDoubleValue(m);
 }
 
-var delete = func {
+var clear = func {
   if (size(GTX330_digits) > 0) {
     # Remove the last digit
     GTX330_digits = left(GTX330_digits, size(GTX330_digits) - 1);
+  } else {
+    # Stop the stopwatch and reset it.
+    var dlg = globals["__dlg:stopwatch-dialog"];
+    if (dlg != nil) {
+      dlg.stop();
+      dlg.reset();
+    } else {
+      stopwatchDialog.setBoolValue("running", 0);
+      stopwatchDialog.setDoubleValue("accu", 0);
+    }
   }
 }
 	
@@ -190,5 +200,33 @@ var stopwatchStartTime = func {
     }
 }
 
+var startstop = func {
+    var dlg = globals["__dlg:stopwatch-dialog"];
+    if (dlg != nil) {
+        # the stopwatch dialog is open, we must use its functions
+        if (dlg.running) {
+            dlg.stop();
+        } else {
+            dlg.start();
+        }
+    } else {
+        # the stopwatch dialog is closed, we must emulate its functions
+        var r = stopwatchDialog.getNode("running");
+        var running = (r != nil) ? r.getBoolValue() : 0;
+        var time = props.globals.getNode("/sim/time/elapsed-sec");
+        if (running) {
+            var a = stopwatchDialog.getNode("accu");
+            var accu = (a != nil) ? a.getValue() : 0.0;
+            accu += time.getValue() - stopwatchDialog.getValue("start-time");
+            a = stopwatchDialog.getNode("accu", 1);
+            a.setDoubleValue(accu);
+            r.setBoolValue(0);
+        } else {
+            running = 1;
+            stopwatchDialog.setBoolValue("running", running);
+            stopwatchDialog.setDoubleValue("start-time", time.getValue());
+        }
+    }
+}
 
 loop();

--- a/Models/instrumentation/GTX330/GTX330.nas
+++ b/Models/instrumentation/GTX330/GTX330.nas
@@ -136,6 +136,11 @@ GTX330_copycode();
  GTX330_copycode();
 }
 
+var setMode = func(m) {
+  # set the given mode for the transponder
+  GTX330_mode.setDoubleValue(m);
+}
+
 var delete = func {
   if (size(GTX330_codes)) {
     pop(GTX330_codes);

--- a/Models/instrumentation/GTX330/GTX330.nas
+++ b/Models/instrumentation/GTX330/GTX330.nas
@@ -123,6 +123,8 @@ setlistener(batterySwitch, updateDisplay, 0, 0);
 setlistener(GTX330_code, updateDisplayedCode, 0, 1);
 
 var input = func(i) { # The user pressed the button for number i
+    if ((GTX330_mode.getValue() or 0) == 0) return;
+
     if (i <= 7) {
         GTX330_digits = GTX330_digits ~ i;
     }
@@ -141,6 +143,8 @@ var setMode = func(m) {
 }
 
 var vfr = func {
+    if ((GTX330_mode.getValue() or 0) == 0) return;
+
     if (savedBeforeVFR == -1) {
         # Save the current code and set the code to VFR.
         if (GTX330_goodcode.getValue()) {
@@ -159,6 +163,8 @@ var vfr = func {
 }
 
 var clear = func {
+  if ((GTX330_mode.getValue() or 0) == 0) return;
+
   if (size(GTX330_digits) > 0) {
     # Remove the last digit
     GTX330_digits = left(GTX330_digits, size(GTX330_digits) - 1);
@@ -228,11 +234,15 @@ var stopwatchStartTime = func {
 }
 
 var cursor = func {
+    if ((GTX330_mode.getValue() or 0) == 0) return;
+
     # Cancel user input for transponder code.
     GTX330_digits = "";
 }
 
 var startstop = func {
+    if ((GTX330_mode.getValue() or 0) == 0) return;
+
     var dlg = globals["__dlg:stopwatch-dialog"];
     if (dlg != nil) {
         # the stopwatch dialog is open, we must use its functions

--- a/Models/instrumentation/GTX330/GTX330.nas
+++ b/Models/instrumentation/GTX330/GTX330.nas
@@ -227,6 +227,11 @@ var stopwatchStartTime = func {
     }
 }
 
+var cursor = func {
+    # Cancel user input for transponder code.
+    GTX330_digits = "";
+}
+
 var startstop = func {
     var dlg = globals["__dlg:stopwatch-dialog"];
     if (dlg != nil) {

--- a/Models/instrumentation/GTX330/GTX330.nas
+++ b/Models/instrumentation/GTX330/GTX330.nas
@@ -161,7 +161,7 @@ var GTX330_copycode = func {
     codestr = codestr ~ GTX330_codes[i];
   }
   var code = 0;
-  code = code + codestr;
+  code = math.mod(code + codestr, 10000);
   GTX330_code.setValue(code);
 }
 

--- a/Models/instrumentation/GTX330/GTX330.nas
+++ b/Models/instrumentation/GTX330/GTX330.nas
@@ -96,25 +96,6 @@ var updateDisplayedCode = func {
   canvas_elements["squawk"].setText(sprintf("%04d", GTX330_code.getValue()));
 }
 
-
-### Workaround, until https://sourceforge.net/p/flightgear/fgdata/merge-requests/60/ is merged.
-### React directly to changes in the "Radio Frequencies" dialog.
-var onTransponderDigitsChanged = func {
-  var goodcode = 1;
-  var code = 0;
-  for (var i = 3; i >= 0 ; i -= 1) {
-    goodcode = goodcode and (num(getprop("/instrumentation/transponder/inputs/digit[" ~ i ~ "]")) != nil) ;
-    code = code * 10 + (num(getprop("/instrumentation/transponder/inputs/digit[" ~ i ~ "]")) or 0);
-  }
-  if (goodcode) {
-    canvas_elements["squawk"].setText(sprintf("%04d", code));
-  }
-}
-for (var i = 0; i<4; i += 1) {
-  setlistener(props.globals.getNode("/instrumentation/transponder/inputs/digit[" ~ i ~ "]", 1), onTransponderDigitsChanged);
-}
-### End of workaround
-
 updateDisplay();
 updateDisplayedCode();
 setlistener(GTX330_mode, updateDisplay, 0, 0);

--- a/Models/instrumentation/GTX330/GTX330.xml
+++ b/Models/instrumentation/GTX330/GTX330.xml
@@ -163,6 +163,56 @@
     </action>
 </animation>
 
+<animation>
+    <type>pick</type>
+    <object-name>off.btn</object-name>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>GTX330.setMode(0);</script>
+        </binding>
+    </action>
+</animation>
 
-    
+<animation>
+    <type>pick</type>
+    <object-name>stby.btn</object-name>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>GTX330.setMode(1);</script>
+        </binding>
+    </action>
+</animation>
+
+<animation>
+    <type>pick</type>
+    <object-name>on.btn</object-name>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>GTX330.setMode(4);</script>
+        </binding>
+    </action>
+</animation>
+
+<animation>
+    <type>pick</type>
+    <object-name>alt.btn</object-name>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>GTX330.setMode(5);</script>
+        </binding>
+    </action>
+</animation>
+
 </PropertyList>

--- a/Models/instrumentation/GTX330/GTX330.xml
+++ b/Models/instrumentation/GTX330/GTX330.xml
@@ -165,6 +165,19 @@
 
 <animation>
     <type>pick</type>
+    <object-name>cursor.btn</object-name>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>GTX330.cursor();</script>
+        </binding>
+    </action>
+</animation>
+
+<animation>
+    <type>pick</type>
     <object-name>startstop.btn</object-name>
     <action>
         <button>0</button>

--- a/Models/instrumentation/GTX330/GTX330.xml
+++ b/Models/instrumentation/GTX330/GTX330.xml
@@ -158,7 +158,20 @@
         <repeatable>false</repeatable>
         <binding>
             <command>nasal</command>
-            <script>GTX330.delete();</script>
+            <script>GTX330.clear();</script>
+        </binding>
+    </action>
+</animation>
+
+<animation>
+    <type>pick</type>
+    <object-name>startstop.btn</object-name>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>GTX330.startstop();</script>
         </binding>
     </action>
 </animation>

--- a/Models/instrumentation/GTX330/GTX330.xml
+++ b/Models/instrumentation/GTX330/GTX330.xml
@@ -228,4 +228,17 @@
     </action>
 </animation>
 
+<animation>
+    <type>pick</type>
+    <object-name>vfr.btn</object-name>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>GTX330.vfr();</script>
+        </binding>
+    </action>
+</animation>
+
 </PropertyList>


### PR DESCRIPTION
Most of the buttons on the GTX330 work now:
* numbers (0-7) to enter a transponder code
* VFR to enter 7000
* START/STOP to start or stop the stopwatch
* CLR to delete the digit that was last entered or to reset the stopwatch
* CRSR to delete all entered digits

Also all inputs are disabled if the GTX330 is in mode OFF.

And I removed a workaround that since FG 2016.2 is not necessary any more.