### PR TITLE
No shutdown sound on init

### DIFF
--- a/Nasal/ec135.nas
+++ b/Nasal/ec135.nas
@@ -282,7 +282,7 @@ var Engine = {
 			}
 
 		} elsif (power < 0.05 or !fuel.levelSupply(me.engineNumber)) {
-			me.runningN.setBoolValue(0);
+			me.runningN.setBoolValue(me.running = 0);
 			me.timer.stop();
 		} else {
 			me.fuelflow = power;

--- a/Sounds/sound.xml
+++ b/Sounds/sound.xml
@@ -64,6 +64,13 @@
 				<not>
 					<property>engines/engine[0]/running</property>
 				</not>
+				<not>
+					<property>controls/engines/engine[0]/starter</property>
+				</not>
+				<greater-than>
+					<property>engines/engine[0]/n1-pct</property>
+					<value>0.1</value>
+				</greater-than>
 			</condition>
 			<volume>
 				<property>sim/model/ec135/sound/volume_external</property>
@@ -133,6 +140,13 @@
 				<not>
 					<property>engines/engine[1]/running</property>
 				</not>
+				<not>
+					<property>controls/engines/engine[1]/starter</property>
+				</not>
+				<greater-than>
+					<property>engines/engine[1]/n1-pct</property>
+					<value>0.1</value>
+				</greater-than>
 			</condition>
 			<volume>
 				<property>sim/model/ec135/sound/volume_external</property>
@@ -393,6 +407,13 @@
 			<not>
 			<property>engines/engine[0]/running</property>
 			</not>
+			<not>
+				<property>controls/engines/engine[0]/starter</property>
+			</not>
+			<greater-than>
+				<property>engines/engine[0]/n1-pct</property>
+				<value>0.1</value>
+			</greater-than>
 			</condition>
 			<volume>
 				<property>sim/model/ec135/sound/volume_internal</property>
@@ -451,6 +472,13 @@
 			<not>
 			<property>engines/engine[1]/running</property>
 			</not>
+			<not>
+				<property>controls/engines/engine[1]/starter</property>
+			</not>
+			<greater-than>
+				<property>engines/engine[1]/n1-pct</property>
+				<value>0.1</value>
+			</greater-than>
 			</condition>
 			<volume>
 				<property>sim/model/ec135/sound/volume_internal</property>


### PR DESCRIPTION
When starting FlightGear the shutdown sounds for both engines were played. This PR adds more conditions to avoid that:
* N1 greater than 0.1%
* Starter switched off

The second condition is necessary because the property `running` is set only when reaching 17% N1, so without it the shutdown sound would be played during startup.
The N1-condition can not be set to 17%, because the sounds stops playing once the value drops below the limit.

While working on this, I fixed a small bug: The property `running` was only set to `TRUE` on the first start of an engine. Subsequent starts would not set the property again.