### PR TITLE
Fix some electrical issues

### DIFF
--- a/Models/instrumentation/dme/DME.xml
+++ b/Models/instrumentation/dme/DME.xml
@@ -35,7 +35,7 @@
    <red>0.79</red>
    <green>0.39</green>
    <blue>0.198</blue>
-   <factor-prop>systems/electrical/outputsinstrument-lights-norm</factor-prop>
+   <factor-prop>systems/electrical/outputs/instrument-lights-norm</factor-prop>
   </emission>
  </animation>   
 

--- a/Nasal/Electrical.nas
+++ b/Nasal/Electrical.nas
@@ -465,6 +465,7 @@ var alternator1_volts = alternator1.get_output_volts();
    Amps.setValue(ammeter_ave);
    Volts.setValue(bus_volts);
     alternator1.apply_load(load);
+    alternator2.apply_load(load);
 
 return load;
 }

--- a/Nasal/Electrical.nas
+++ b/Nasal/Electrical.nas
@@ -397,6 +397,7 @@ update_virtual_bus = func( dt ) {
 	load = 0.0;
 	bus_volts = 0.0;
 	power_source = nil;
+	lbus_volts = battery_volts;
 	rbus_volts = battery_volts;
 	bus_volts = battery_volts;
 	power_source = "battery";


### PR DESCRIPTION
This PR fixes some issues in the electrical system:
* The DME used a mistyped property for instrument lighting.
* The load was only applied to the left generator, e.g. `systems/electrical/gen-load[1]` was always 0.
* Power from the left generator was not used, e.g. the battery would drain when only the left engine was running.